### PR TITLE
Auto-rename `out=` files with the `.pb.gz` extension if not provided.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PProf"
 uuid = "e4faabce-9ead-11e9-39d9-4379958e3056"
 authors = ["Valentin Churavy <v.churavy@gmail.com>", "Nathan Daly <nhdaly@gmail.com>"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"

--- a/src/PProf.jl
+++ b/src/PProf.jl
@@ -104,6 +104,11 @@ function pprof(data::Union{Nothing, Vector{UInt}} = nothing,
     if period === nothing
         period = ccall(:jl_profile_delay_nsec, UInt64, ())
     end
+    @assert !isempty(basename(out)) "`out=` must specify a file path to write to. Got unexpected: '$out'"
+    if !endswith(out, ".pb.gz")
+        out = "$out.pb.gz"
+        @info "Writing output to $out"
+    end
 
     string_table = OrderedDict{AbstractString, Int64}()
     enter!(string) = _enter!(string_table, string)


### PR DESCRIPTION
Adds tests for this as well.

CC: @tomasrelai