### PR TITLE
Add `ui_relative_percentages=true` which controls `-relative_percentages` in pprof.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PProf"
 uuid = "e4faabce-9ead-11e9-39d9-4379958e3056"
 authors = ["Valentin Churavy <v.churavy@gmail.com>", "Nathan Daly <nhdaly@gmail.com>"]
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"


### PR DESCRIPTION
By default, this now causes `ignore`/`hide` events through the Web UI to
recompute percentages.

This allows you to filter out parts of the program that aren't relevant
to what you're measuring, such as `__psynch_cvwait` in a single-threaded
program.

However, sometimes users may simply be using `ignore`/`hide` to get a
"cleaner" view of their data, but very much _don't_ want filtering the
_view_ to affect the underlying data. In that case, users can disable
this feature via `ui_relative_percentages=false`


----------

I called the flag `ui_relative_percentages` instead of `relative_percentages`, because it is only meaningful if opening the web ui, not when just generating a `.pb.gz` dump.

Addresses step 1 of #19.