### PR TITLE
create a new PProf.jl release with the new pprof_jll

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PProf"
 uuid = "e4faabce-9ead-11e9-39d9-4379958e3056"
 authors = ["Valentin Churavy <v.churavy@gmail.com>", "Nathan Daly <nhdaly@gmail.com>"]
-version = "4.0.0"
+version = "3.2.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"


### PR DESCRIPTION
Bumping it to 4.0.0 seems correct here given that we're updating the underlying JLL and introducing new features -- e.g. `flamegraph2`. Reviews on that are welcome though.